### PR TITLE
Fix loading data bug

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -86,8 +86,8 @@ public class MainApp extends Application {
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataLoadingException e) {
             logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
-                    + " Will be starting with an empty AddressBook.");
-            initialData = new AddressBook();
+                    + " Will be starting with a sample AddressBook.");
+            initialData = SampleDataUtil.getSampleAddressBook();
         }
 
         return new ModelManager(initialData, userPrefs);


### PR DESCRIPTION
Initially, an error in the JSON file caused an empty Addressbook to be loaded. This can cause the user to be confused as to what can be done, thus we made a sample data be loaded when a bug occurred.

This fixes the AB3 requirement where a sample addressbook should be loaded when the save file is corrupted